### PR TITLE
Use Actions Artifacts for latest

### DIFF
--- a/.github/workflows/process-data.yml
+++ b/.github/workflows/process-data.yml
@@ -2,7 +2,7 @@ name: process-data
 on:
   schedule:
     - cron: "30 3 * * 0"   # Run weekly at 03:30 on Sunday
-    # 1 hour after setup-koordinates-exports job runs to allow exports to build
+    # 1 hour after setup-koordinates-exports job runs to allow export archives to process
 
 jobs:
   process-data:
@@ -85,10 +85,11 @@ jobs:
 
       - name: Generate artifact name
         id: generate-name
-        run: echo "artifact=open_nz_postcode_boundaries_shp_`date +%Y-%m-%d`_index.zip" >> $GITHUB_OUTPUT
+        run: echo "artifact=open_nz_postcode_boundaries_shp_`date +%Y-%m-%d`" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.generate-name.outputs.artifact }}
           path: release/open_nz_postcode_boundaries_shp.zip
+          retention-days: 30

--- a/.github/workflows/process-data.yml
+++ b/.github/workflows/process-data.yml
@@ -1,6 +1,5 @@
 name: process-data
 on:
-  push:                # temp
   schedule:
     - cron: "30 3 * * 0"   # Run weekly at 03:30 on Sunday
     # 1 hour after setup-koordinates-exports job runs to allow export archives to process

--- a/.github/workflows/process-data.yml
+++ b/.github/workflows/process-data.yml
@@ -1,5 +1,6 @@
 name: process-data
 on:
+  push:                # temp
   schedule:
     - cron: "30 3 * * 0"   # Run weekly at 03:30 on Sunday
     # 1 hour after setup-koordinates-exports job runs to allow export archives to process

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 An openly licenced (unofficial) dataset of New Zealand postcodes with geospatial representation as digital boundaries.
 
-Boundary files are generated automatically using latest upstream data weekly via GitHub Actions. Download the file from "Artifacts" in the latest/top [Workflow Run](https://github.com/s01ipsist/open_nz_postcodes/actions/workflows/process-data.yml)
+Latest boundary shapefiles can be downloaded from "Artifacts" in the latest/top [Workflow Run](https://github.com/s01ipsist/open_nz_postcodes/actions/workflows/process-data.yml).
+
+Boundary files are generated automatically using latest upstream data weekly via GitHub Actions.
 
 ![Sample output for Auckland central area](images/sample-auckland.png)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An openly licenced (unofficial) dataset of New Zealand postcodes with geospatial representation as digital boundaries.
 
-See [Releases](https://github.com/s01ipsist/open_nz_postcodes/releases) to download the latest boundary files.
+Boundary files are generated automatically using latest upstream data weekly via GitHub Actions. Download the file from "Artifacts" in the latest/top [Workflow Run](https://github.com/s01ipsist/open_nz_postcodes/actions/workflows/process-data.yml)
 
 ![Sample output for Auckland central area](images/sample-auckland.png)
 


### PR DESCRIPTION
GitHub Releases are tied to Tags, but the repo code may not change between upstream data changes so it feels a poor fit for automated updates.

Documents how to get latest from Actions Artifacts.

Manual releases are still an option. 🤔 