### PR TITLE
Add cache purger

### DIFF
--- a/.github/workflows/process-data.yml
+++ b/.github/workflows/process-data.yml
@@ -1,8 +1,12 @@
 name: process-data
 on:
+  workflow_dispatch:
   schedule:
     - cron: "30 20 * * 1"   # Run weekly at 20:30 on Monday
     # 1 hour after setup-koordinates-exports job runs to allow export archives to process
+
+permissions:
+  actions: write    # For managing Actions cache
 
 jobs:
   process-data:
@@ -35,6 +39,12 @@ jobs:
 
       - name: Create download data folder
         run: mkdir -p scripts/koordinates/data
+
+      - name: Remove stale caches
+        working-directory: ./scripts
+        run: bash cache-purger.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore cached download
         id: cache-nz-koordinates

--- a/scripts/cache-purger.sh
+++ b/scripts/cache-purger.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Define the cache key to look for
+CACHE_KEY="Linux-nz-koordinates"
+
+# Get the current time in epoch format
+CURRENT_TIME=$(date +%s)
+
+# List caches, filter by key, and process each result
+# https://cli.github.com/manual/gh_cache_list
+gh cache list --json key,createdAt,id | jq -c ".[] | select(.key == \"$CACHE_KEY\")" | while read -r cache; do
+  # Extract the cache ID and creation timestamp
+  CACHE_ID=$(echo "$cache" | jq -r '.id')
+  CREATED_AT=$(echo "$cache" | jq -r '.createdAt')
+
+  # Convert the creation time to epoch format
+  CREATED_AT_EPOCH=$(date -d "$CREATED_AT" +%s)
+
+  # Calculate the age of the cache in seconds
+  AGE=$((CURRENT_TIME - CREATED_AT_EPOCH))
+
+  # Check if the cache is older than 24 hours (86400 seconds)
+  if [ $AGE -gt 86400 ]; then
+    echo "Deleting cache with ID $CACHE_ID (created at $CREATED_AT)"
+    gh cache delete "$CACHE_ID"
+  else
+    echo "Cache with ID $CACHE_ID is not older than 24 hours (created at $CREATED_AT)"
+  fi
+done


### PR DESCRIPTION
We use Github Actions cache to avoid abuse of the Koordinates service.
Github Actions cache will be retained if accessed within 7 days from last access.
As this action runs every 7 days, it means the original cache is retained indefinitely.
This PR introduces a call to clear caches older than 24 hrs to ensure we don't abuse the service during development, but still refresh the cache during regular programming.