### PR TITLE
Ruby 3.4 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3
+FROM ruby:3.4
 
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     # https://hub.docker.com/r/postgis/postgis
     # arm64 image required for MacOS development
     # image: postgis/postgis # not arm64 friendly https://github.com/postgis/docker-postgis/issues/216
-    image: imresamu/postgis:16-3.4 # arm64 # https://hub.docker.com/r/imresamu/postgis/tags
+    image: imresamu/postgis # arm64 # https://hub.docker.com/r/imresamu/postgis/tags
     restart: always
     shm_size: 1gb
     environment:


### PR DESCRIPTION
Update build image from Ruby 3.3 to 3.4.
Stop pinning postgis image in dev.