### PR TITLE
Modernize dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/scripts/koordinates"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/process-data.yml
+++ b/.github/workflows/process-data.yml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       postgres:
-        image: postgis/postgis
+        image: postgis/postgis:18-3.6
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
         # Set health checks to wait until postgres has started

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:4.0
+FROM debian:bookworm-slim
 
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \

--- a/scripts/koordinates/requirements.txt
+++ b/scripts/koordinates/requirements.txt
@@ -1,4 +1,2 @@
 # https://koordinates-python.readthedocs.io/en/stable/
 koordinates
-# https://stackoverflow.com/questions/76175487/sudden-importerror-cannot-import-name-appengine-from-requests-packages-urlli
-appengine-python-standard


### PR DESCRIPTION
- Drop stale appengine-python-standard workaround; koordinates imports cleanly without it
- Pin process-data workflow postgis image to 18-3.6 (matches local dev)
- Add pip ecosystem to Dependabot for scripts/koordinates
- Switch Dockerfile base from ruby:4.0 to debian:bookworm-slim (no Ruby in repo)