### PR TITLE
Surface run metrics via GITHUB_STEP_SUMMARY

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -10,7 +10,18 @@ psql -d open_nz_postcodes -f scripts/setup-postcode-boundaries.sql
 psql -A -d open_nz_postcodes -f scripts/checks.sql
 
 NEW_ROADS_COUNT=$(psql -At -d open_nz_postcodes -c "SELECT COUNT(*) FROM nz_roads LEFT OUTER JOIN nz_street_postcodes ON (nz_street_postcodes.road_id = nz_roads.road_id) WHERE (nz_street_postcodes.road_id IS NULL) AND full_road_ IS NOT NULL;")
-echo "::notice::New roads to add (see add-new-roads.sql): ${NEW_ROADS_COUNT}"
+PRECISION=$(psql -At -d open_nz_postcodes -c "SELECT ROUND((SUM(count_matching_address_points)::numeric / NULLIF(SUM(count_matching_address_points) + SUM(count_non_matching_address_points), 0)) * 100, 2) FROM postcode_boundaries;")
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+## Run summary
+
+| Metric | Value |
+| --- | --- |
+| Precision | ${PRECISION}% |
+| New roads to add ([add-new-roads.sql](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/main/scripts/add-new-roads.sql)) | ${NEW_ROADS_COUNT} |
+EOF
+fi
 
 # optional: simplify topographies to reduce generated shapefile size from 90mb to 2mb
 # psql -d open_nz_postcodes -c "UPDATE postcode_boundaries SET geom = ST_Simplify(geom, 0.001);"


### PR DESCRIPTION
Replace the per-run notice annotation with a markdown summary that renders on the workflow run page. Includes:

- Overall precision (% of address points landing in a boundary of the matching postcode) — previously only visible by grepping checks.sql output in CI logs.
- New roads to add — count of LINZ roads missing from nz_street_postcodes, linked to scripts/add-new-roads.sql.

The block is guarded by ${GITHUB_STEP_SUMMARY:-} so local runs of run.sh stay quiet.