### PR TITLE
Fix shell script set -eof typo

### DIFF
--- a/scripts/export-street-postcodes.sh
+++ b/scripts/export-street-postcodes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eof
+set -euo pipefail
 
 # Export current street postcodes
 # https://www.postgresql.org/docs/current/sql-copy.html

--- a/scripts/extract-export-data.sh
+++ b/scripts/extract-export-data.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eof
+set -euo pipefail
 
 mkdir -p data
 

--- a/scripts/import-geodata.sh
+++ b/scripts/import-geodata.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eof
+set -euo pipefail
 
 # Datasets come in various coordinate systems
 # transform everything into WGS84 - World Geodetic System 1984

--- a/scripts/import-street-postcodes.sh
+++ b/scripts/import-street-postcodes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eof
+set -euo pipefail
 
 echo "-- Importing nz_street_postcodes"
 psql -d open_nz_postcodes -c "CREATE TABLE IF NOT EXISTS nz_street_postcodes (road_id integer, postcode text, name text, locality text, city text);"

--- a/scripts/rerun.sh
+++ b/scripts/rerun.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eof
+set -euo pipefail
 
 # useful during development after LINZ/Stats data already imported
 # but postcode data or scripts changed

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eof
+set -euo pipefail
 
 echo "-- BEGIN $(date)"
 

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eof
+set -euo pipefail
 
 # USAGE: docker compose run --rm app scripts/run_local.sh
 

--- a/scripts/setup-koordinates-data.sh
+++ b/scripts/setup-koordinates-data.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eof
+set -euo pipefail
 
 echo "-- BEGIN $(date)"
 


### PR DESCRIPTION
set -eof is parsed as -e -o -f, where bare -o lists shell options (visible as the braceexpand/errexit/... dump at the start of every run) and -f disables globbing. The intent was -euo pipefail: fail on error, treat unset vars as errors, and fail pipelines if any stage errors.

Applied to: run.sh, run_local.sh, rerun.sh, import-geodata.sh, import-street-postcodes.sh, setup-koordinates-data.sh, extract-export-data.sh, export-street-postcodes.sh.

Verified by running scripts/run.sh end-to-end in the docker compose environment: pipeline completes successfully and no longer prints the shell options dump.