### PR TITLE
Centralize year and meshblock layer id

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -1,0 +1,8 @@
+# Centralized pipeline constants.
+# Sourced by shell scripts and parsed by scripts/koordinates/config.py.
+#
+# Bump YEAR when Stats NZ publishes a new annual meshblock vintage,
+# and update MESHBLOCK_LAYER_ID with the matching layer ID from
+# https://datafinder.stats.govt.nz/data/category/geographic/.
+export YEAR=2026
+export MESHBLOCK_LAYER_ID=123521

--- a/scripts/extract-export-data.sh
+++ b/scripts/extract-export-data.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
+source "$(dirname "$0")/config.sh"
+
 mkdir -p data
 
-# source file names from DATA_SOURCES in scripts/koordinates/export_downloads.py
-mv scripts/koordinates/data/linz-koord-2026.zip data/linz-koord.zip
-mv scripts/koordinates/data/statsnz-koord-2026a.zip data/statsnz-koord.zip
+# source file names from DATA_SOURCES in scripts/koordinates/config.py
+mv scripts/koordinates/data/linz-koord-${YEAR}.zip data/linz-koord.zip
+mv scripts/koordinates/data/statsnz-koord-${YEAR}a.zip data/statsnz-koord.zip
 
 cd data
 unzip -o linz-koord.zip

--- a/scripts/import-geodata.sh
+++ b/scripts/import-geodata.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "$(dirname "$0")/config.sh"
+
 # Datasets come in various coordinate systems
 # transform everything into WGS84 - World Geodetic System 1984
 # Coordinate systems used:
@@ -18,7 +20,7 @@ rm -f data/tmp/*.sql
 path_addresses_1=data/nz-addresses/nz-addresses.shp
 path_roads=data/nz-addresses-roads/nz-addresses-roads.shp
 path_suburbs=data/nz-suburbs-and-localities/nz-suburbs-and-localities.shp
-path_meshblocks=data/meshblock-2026.shp
+path_meshblocks=data/meshblock-${YEAR}.shp
 
 # check that data assets are in place
 for x in ${!path_@}; do

--- a/scripts/koordinates/config.py
+++ b/scripts/koordinates/config.py
@@ -1,5 +1,21 @@
 import os
 
+
+def _parse_config_sh(path):
+    settings = {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith('export '):
+                key, _, value = line[len('export '):].partition('=')
+                settings[key] = value
+    return settings
+
+
+_cfg = _parse_config_sh(os.path.join(os.path.dirname(__file__), '..', 'config.sh'))
+YEAR = int(_cfg['YEAR'])
+MESHBLOCK_LAYER_ID = int(_cfg['MESHBLOCK_LAYER_ID'])
+
 LINZ_API_TOKEN = os.environ['LINZ_DATA_API_TOKEN']
 STATSNZ_API_TOKEN = os.environ['STATSNZ_DATA_API_TOKEN']
 
@@ -7,11 +23,10 @@ STATSNZ_API_TOKEN = os.environ['STATSNZ_DATA_API_TOKEN']
 # https://data.linz.govt.nz/layer/123113-nz-addresses/
 # https://data.linz.govt.nz/layer/123110-nz-addresses-roads/
 # https://data.linz.govt.nz/layer/113764-nz-suburbs-and-localities/
-# https://datafinder.stats.govt.nz/layer/123521-meshblock-2026/
 
 DATA_SOURCES = {
     'linz': {
-        'name': 'linz-koord-2026',
+        'name': f'linz-koord-{YEAR}',
         'host': 'data.linz.govt.nz',
         'token': LINZ_API_TOKEN,
         'crs': 'EPSG:4167',
@@ -19,12 +34,12 @@ DATA_SOURCES = {
         'layers': [123113, 123110, 113764]
     },
     'statsnz': {
-        'name': 'statsnz-koord-2026a',
+        'name': f'statsnz-koord-{YEAR}a',
         'host': 'datafinder.stats.govt.nz',
         'token': STATSNZ_API_TOKEN,
         'crs': 'EPSG:2193',
         'format': 'application/x-zipped-shp',
-        'layers': [123521]
+        'layers': [MESHBLOCK_LAYER_ID]
     }
 }
 


### PR DESCRIPTION
Bumping to a new Stats NZ meshblock vintage previously touched 5 places across 3 files (import-geodata.sh, extract-export-data.sh, koordinates/config.py). Move both values into scripts/config.sh as the single source of truth.

- scripts/config.sh: sourced by shell scripts, exports YEAR and MESHBLOCK_LAYER_ID.
- scripts/koordinates/config.py: parses config.sh directly so Python consumers stay in sync without env-var plumbing in CI.
- import-geodata.sh: meshblock path now uses ${YEAR}.
- extract-export-data.sh: zip filenames now use ${YEAR}.

Verified by running scripts/run.sh end-to-end against the current LINZ snapshot: 1073 boundaries generated, same as previous runs.